### PR TITLE
Update the `addOnHook` priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.2] - 2018-04-18
+### Updated
+- Make sure the `addOnHook` action priority is set minus 2 so when `initializeOnHook` is called on the
+same hook tag it can execute.
+
 ## [1.1.1] - 2018-04-04
 ### Updated
 - Added the `initialize` method in `AbstractPlugin` since it's no longer extending `Init`.

--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ compatibility is entirely coincidental.
 To install this library, use Composer:
 
 ```
-composer require thefrosty/wp-utilities:~1.1.1
+composer require thefrosty/wp-utilities:~1.1.2
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "thefrosty/wp-utilities",
   "description": "A library containing my standard development resources",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "authors": [
     {

--- a/src/Plugin/AbstractPlugin.php
+++ b/src/Plugin/AbstractPlugin.php
@@ -246,7 +246,7 @@ abstract class AbstractPlugin implements PluginInterface
             } elseif ($admin_only === null) {
                 $this->initiateWpHooks($wp_hook);
             }
-        }, $priority ?? 10);
+        }, ($priority ?? 10) - 2);
 
         return $this;
     }

--- a/src/Plugin/AbstractPlugin.php
+++ b/src/Plugin/AbstractPlugin.php
@@ -238,13 +238,13 @@ abstract class AbstractPlugin implements PluginInterface
     ) : PluginInterface {
         $tag = $tag ?? self::DEFAULT_TAG;
         $this->setTags($tag);
-        \add_action($tag, function () use ($wp_hook, $admin_only) {
+        \add_action($tag, function () use ($wp_hook, $admin_only, $priority) {
             if ($admin_only === true && \is_admin()) {
-                $this->initiateWpHooks($wp_hook);
+                $this->initiateWpHooks($wp_hook, $priority);
             } elseif ($admin_only === false && ! \is_admin()) {
-                $this->initiateWpHooks($wp_hook);
+                $this->initiateWpHooks($wp_hook, $priority);
             } elseif ($admin_only === null) {
-                $this->initiateWpHooks($wp_hook);
+                $this->initiateWpHooks($wp_hook, $priority);
             }
         }, ($priority ?? 10) - 2);
 
@@ -263,8 +263,10 @@ abstract class AbstractPlugin implements PluginInterface
      * Initialize the late hook provider when it's been registered on an action hook.
      *
      * @param string $wp_hook String value of the WpHooksInterface hook provider.
+     * @param int $priority Optional. Used to specify the order in which the functions
+     *                                  associated with a particular action are executed. Default 10.
      */
-    private function initiateWpHooks(string $wp_hook)
+    private function initiateWpHooks(string $wp_hook, int $priority = 10)
     {
         $wp_hooks = new $wp_hook();
         if (! ($wp_hooks instanceof WpHooksInterface)) {
@@ -274,19 +276,22 @@ abstract class AbstractPlugin implements PluginInterface
         }
         /** @var WpHooksInterface $wp_hooks */
         $this->getInit()->register($wp_hooks, $this);
-        $this->initializeOnHook();
+        $this->initializeOnHook($priority);
     }
 
     /**
      * Iterate over all registered tag's and re-initialize the WpHooksInterface objects to
      * initiate their hooks on the appropriate registered action (tag).
+     *
+     * @param int $priority Optional. Used to specify the order in which the functions
+     *                                  associated with a particular action are executed. Default 10.
      */
-    private function initializeOnHook()
+    private function initializeOnHook(int $priority = 10)
     {
-        call_user_func_array(function ($tag) {
+        call_user_func_array(function ($tag) use ($priority) {
             \add_action($tag, function () {
                 $this->getInit()->initialize();
-            });
+            }, $priority + 2);
         }, $this->getTags());
     }
 


### PR DESCRIPTION
When the priority isn't set `initializeOnHook` is called on the same tag at the same priority meaning the new WpHook object can't instantiate.