### PR TITLE
Add `wpQueryGetAllIdsCached` to compliment `wpQueryGetAllIds` in `WpQueryTrait`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Add deprecation notice for parameter `$expiration` in `WpQueryTrait::wpQueryGetAllIds`.
+- Add `WpQueryTrait::wpQueryGetAllIdsCached` to compliment `WpQueryTrait::wpQueryGetAllIds` without 
+  utilizing cached query calls, if desired.
+- Update johnbillion/args requirement from ^0.2.0 to ^0.4.0 [#57](https://github.com/thefrosty/wp-utilities/pull/57)
+
 ## [2.3.0] - 2021-06-08
 
 - Update HooksTrait with new methods: `addFilterOnce`, `addActionOnce`, `doAction`, and `applyFilters`.


### PR DESCRIPTION

- Add deprecation notice for parameter `$expiration` in `WpQueryTrait::wpQueryGetAllIds`.
- Add `WpQueryTrait::wpQueryGetAllIdsCached` to compliment `WpQueryTrait::wpQueryGetAllIds` without 
  utilizing cached query calls, if desired.