### PR TITLE
Bug/wp get all ids/remove static

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ dist: focal
 
 env:
   global:
-    - WP_VERSION=5.7.1
+    - WP_VERSION=5.8.0
     - WP_MULTISITE=0
     - XDEBUG_MODE=coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.4.2] - 2021-08-12
+
+- Remove the `static` from the `$paged` variable in `WpQueryTrait::wpGetAllIds()` allowing multiple calls to 
+  `wpGetAllIds` without affecting current scope count.
+
 ## [2.4.1] - 2021-07-01
 
 - Set defaults in a method in `WpQueryTrait` that can be filtered with `thefrosty/wp_utilities/wp_query_defaults`. 

--- a/src/Api/WpQueryTrait.php
+++ b/src/Api/WpQueryTrait.php
@@ -112,15 +112,14 @@ trait WpQueryTrait
         ?int $expiration = null
     ): array {
 
-        static $paged;
+        $paged = 0;
         $post_ids = [];
         do {
-            $paged++; // phpcs:ignore
             $defaults = [
                 'fields' => 'ids',
                 'posts_per_page' => 100,
                 'no_found_rows' => false, // We need pagination & the count for all posts found.
-                'paged' => $paged,
+                'paged' => $paged++, // phpcs:ignore
                 'update_post_term_cache' => false,
                 'update_post_meta_cache' => false,
             ];


### PR DESCRIPTION
Remove the `static` from the `$paged` variable in `WpQueryTrait::wpGetAllIds()` allowing multiple calls to 
  `wpGetAllIds` without affecting current scope count.