### PR TITLE
Add Legacy PSR Container Support (#103)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "optimize-autoloader": true,
     "platform": {
-      "php": "7.4.26"
+      "php": "7.4"
     },
     "sort-packages": true
   },
@@ -28,7 +28,7 @@
     "ext-json": "*",
     "ext-openssl": "*",
     "johnbillion/args": "^1.1",
-    "psr/container": "^2.0.2"
+    "psr/container": "^1.0 || ^2.0"
   },
   "require-dev": {
     "ext-simplexml": "*",

--- a/src/Plugin/AbstractContainerProvider.php
+++ b/src/Plugin/AbstractContainerProvider.php
@@ -2,6 +2,8 @@
 
 namespace TheFrosty\WpUtilities\Plugin;
 
+use Psr\Container\ContainerInterface;
+
 /**
  * Class AbstractContainerProvider
  * @package TheFrosty\WpUtilities\Plugin
@@ -12,13 +14,11 @@ abstract class AbstractContainerProvider implements WpHooksInterface, PluginAwar
 
     /**
      * AbstractContainerProvider constructor.
-     * @param Container|null $container Set the container, or use `$this->setContainer($container)`.
+     * @param Container|ContainerInterface|null $container Set the container, or use `$this->setContainer($container)`.
      */
-    public function __construct(?Container $container = null)
+    public function __construct(?ContainerInterface $container = null)
     {
-        if ($container) {
-            $this->setContainer($container);
-        }
+        $this->setContainer($container);
     }
 
     /**

--- a/src/Plugin/Container100.php
+++ b/src/Plugin/Container100.php
@@ -6,15 +6,14 @@ use Pimple\Container as Pimple;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use ReturnTypeWillChange;
 
 /**
- * Container class.
- * Extends Pimple to satisfy the ContainerInterface >= v2.0.0.
- * @ref https://github.com/php-fig/container/blob/2.0.0/src/ContainerInterface.php
+ * Container100 class.
+ * Extends Pimple to satisfy the ContainerInterface v1.0.0.
+ * @ref https://github.com/php-fig/container/blob/1.0.0/src/ContainerInterface.php
  * @package TheFrosty\WpUtilities\Plugin
  */
-class Container extends Pimple implements ContainerInterface
+class Container100 extends Pimple implements ContainerInterface
 {
 
     /**
@@ -26,8 +25,7 @@ class Container extends Pimple implements ContainerInterface
      * @throws ContainerExceptionInterface Error while retrieving the entry.
      * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
      */
-    #[ReturnTypeWillChange]
-    public function get(string $id)
+    public function get($id)
     {
         return $this->offsetGet($id);
     }
@@ -42,8 +40,7 @@ class Container extends Pimple implements ContainerInterface
      * @param string $id Identifier of the entry to look for.
      * @return bool
      */
-    #[ReturnTypeWillChange]
-    public function has(string $id): bool
+    public function has($id)
     {
         return $this->offsetExists($id);
     }

--- a/src/Plugin/Container110.php
+++ b/src/Plugin/Container110.php
@@ -6,15 +6,14 @@ use Pimple\Container as Pimple;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use ReturnTypeWillChange;
 
 /**
- * Container class.
- * Extends Pimple to satisfy the ContainerInterface >= v2.0.0.
- * @ref https://github.com/php-fig/container/blob/2.0.0/src/ContainerInterface.php
+ * Container110 class.
+ * Extends Pimple to satisfy the ContainerInterface v1.1.0
+ * @ref https://github.com/php-fig/container/blob/1.1.0/src/ContainerInterface.php.
  * @package TheFrosty\WpUtilities\Plugin
  */
-class Container extends Pimple implements ContainerInterface
+class Container110 extends Pimple implements ContainerInterface
 {
 
     /**
@@ -26,7 +25,6 @@ class Container extends Pimple implements ContainerInterface
      * @throws ContainerExceptionInterface Error while retrieving the entry.
      * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
      */
-    #[ReturnTypeWillChange]
     public function get(string $id)
     {
         return $this->offsetGet($id);
@@ -42,8 +40,7 @@ class Container extends Pimple implements ContainerInterface
      * @param string $id Identifier of the entry to look for.
      * @return bool
      */
-    #[ReturnTypeWillChange]
-    public function has(string $id): bool
+    public function has(string $id)
     {
         return $this->offsetExists($id);
     }

--- a/src/Plugin/ContainerAwareTrait.php
+++ b/src/Plugin/ContainerAwareTrait.php
@@ -16,10 +16,10 @@ trait ContainerAwareTrait
 {
 
     /**
-     * Container.
-     * @var ContainerInterface
+     * Container instance.
+     * @var ContainerInterface|null
      */
-    private ContainerInterface $container;
+    private ?ContainerInterface $container;
 
     /**
      * Proxy access to container services.
@@ -29,7 +29,7 @@ trait ContainerAwareTrait
      */
     public function __get(string $name)
     {
-        return $this->container->get($name);
+        return $this->container && $this->container->get($name);
     }
 
     /**
@@ -40,7 +40,7 @@ trait ContainerAwareTrait
      */
     public function __isset(string $name): bool
     {
-        return $this->container->has($name);
+        return $this->container && $this->container->has($name);
     }
 
     /**
@@ -53,7 +53,7 @@ trait ContainerAwareTrait
      */
     public function __call(string $method, array $args)
     {
-        if ($this->container->has($method)) {
+        if ($this->container && $this->container->has($method)) {
             $object = $this->container->get($method);
             if (\is_callable($object)) {
                 return \call_user_func_array($object, $args);
@@ -66,9 +66,9 @@ trait ContainerAwareTrait
     /**
      * Enable access to the DI container by plugin consumers.
      *
-     * @return ContainerInterface
+     * @return ContainerInterface|null
      */
-    public function getContainer(): ContainerInterface
+    public function getContainer(): ?ContainerInterface
     {
         return $this->container;
     }
@@ -76,10 +76,10 @@ trait ContainerAwareTrait
     /**
      * Set the container.
      *
-     * @param ContainerInterface $container Dependency injection container.
+     * @param ContainerInterface|null $container Dependency injection container.
      * @return $this
      */
-    public function setContainer(ContainerInterface $container): self
+    public function setContainer(?ContainerInterface $container = null): self
     {
         $this->container = $container;
 

--- a/tests/unit/Plugin/HooksTraitTest.php
+++ b/tests/unit/Plugin/HooksTraitTest.php
@@ -19,7 +19,7 @@ class HooksTraitTest extends TestCase
     {
         $provider = $this->getMockProvider(HookProvider::class);
         $provider->expects($this->exactly(1))
-                 ->method('addFilter')
+                 ->method(self::METHOD_ADD_FILTER)
                  ->will($this->returnCallback(function ($hook, $method, $priority, $arg_count) {
                      TestCase::assertSame('theTitle', $hook);
                      TestCase::assertSame(10, $priority);
@@ -38,7 +38,7 @@ class HooksTraitTest extends TestCase
     {
         $provider = $this->getMockProvider(HookProvider::class);
         $provider->expects($this->exactly(1))
-                 ->method('addFilter')
+                 ->method(self::METHOD_ADD_FILTER)
                  ->will($this->returnCallback(function ($hook, $method, $priority, $arg_count) {
                      TestCase::assertSame('template_redirect', $hook);
                      TestCase::assertSame(10, $priority);

--- a/tests/unit/Plugin/PluginAwareTraitTest.php
+++ b/tests/unit/Plugin/PluginAwareTraitTest.php
@@ -2,6 +2,7 @@
 
 namespace TheFrosty\WpUtilities\Tests\Plugin;
 
+use ReflectionClass;
 use TheFrosty\WpUtilities\Plugin\Plugin;
 use TheFrosty\WpUtilities\Plugin\PluginAwareTrait;
 use TheFrosty\WpUtilities\Tests\Plugin\Framework\TestCase;
@@ -15,26 +16,24 @@ class PluginAwareTraitTest extends TestCase
 {
 
     /**
-     * Test set_plugin()
+     * Test setPlugin()
      */
-    public function test_set_plugin()
+    public function testSetPlugin(): void
     {
-        $provider = $this->getMockForTrait(PluginAwareTrait::class);
+        $provider = new class {
 
-        try {
-            $class = new \ReflectionClass($provider);
-            $property = $class->getProperty('plugin');
-            $property->setAccessible(true);
-        } catch (\ReflectionException $exception) {
-            $this->assertInstanceOf(\ReflectionException::class, $exception);
+            use PluginAwareTrait;
+        };
 
-            return;
-        }
+        $class = new ReflectionClass($provider);
+        $property = $class->getProperty('plugin');
+        $property->setAccessible(true);
 
         $plugin = new Plugin();
         /** PluginAwareTrait @var PluginAwareTrait $provider */
         $provider->setPlugin($plugin);
 
         $this->assertSame($plugin, $property->getValue($provider));
+        $this->assertSame($plugin, $provider->getPlugin());
     }
 }

--- a/tests/unit/Plugin/PluginRegisterHooksTest.php
+++ b/tests/unit/Plugin/PluginRegisterHooksTest.php
@@ -2,6 +2,7 @@
 
 namespace TheFrosty\WpUtilities\Tests\Plugin;
 
+use ReflectionClass;
 use TheFrosty\WpUtilities\Plugin\WpHooksInterface;
 use TheFrosty\WpUtilities\Plugin\AbstractHookProvider;
 use TheFrosty\WpUtilities\Plugin\Plugin;
@@ -17,12 +18,12 @@ class PluginRegisterHooksTest extends TestCase
     /**
      * Test AbstractHookProvider
      */
-    public function test_register_hooks(): void
+    public function testRegisterHooks(): void
     {
         $provider = $this->getMockProviderForAbstractClass(AbstractHookProvider::class);
 
         try {
-            $class = new \ReflectionClass($provider);
+            $class = new ReflectionClass($provider);
             $property = $class->getProperty('plugin');
             $property->setAccessible(true);
         } catch (\ReflectionException $exception) {


### PR DESCRIPTION
* Set the Platform to 7.4 and allow `psr/container` ^1 or ^2.

* Update the docblock.

* Allow nullable property.

* Set the container based on which version of the ContainerInterface is present.

* Add Container classes for support of psr/container 1.0.x, and 1.1.x.

* Unit test code cleanup.

* Change AbstractContainer constructor to Interface.

* Resolve incorrect Unit test.