### PR TITLE
Resolve changed parameter in WordPress 6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,9 @@
     "jjgrainger/posttypes": "Simple WordPress custom post types."
   },
   "autoload": {
+    "files": [
+      "src/functions.php"
+    ],
     "psr-4": {
       "TheFrosty\\WpUtilities\\": "src/"
     }

--- a/src/WpAdmin/RestrictManagePosts.php
+++ b/src/WpAdmin/RestrictManagePosts.php
@@ -20,9 +20,9 @@ use function preg_match;
 use function sanitize_text_field;
 use function sprintf;
 use function strcasecmp;
+use function TheFrosty\WpUtilities\wp_register_script;
 use function wp_enqueue_script;
 use function wp_enqueue_style;
-use function wp_register_script;
 use function wp_register_style;
 use const SCRIPT_DEBUG;
 
@@ -100,13 +100,13 @@ class RestrictManagePosts extends AbstractHookProvider implements HttpFoundation
         wp_register_script(
             self::HANDLE_UTILITY_FUNCTIONS,
             sprintf('https://cdn.jsdelivr.net/gh/thefrosty/wp-utilities@3/assets/js/utilities/functions%s.js', $min),
-            in_footer: true
+            args: ['in_footer' => true]
         );
         wp_register_script(
             self::HANDLE,
             sprintf('https://cdn.jsdelivr.net/gh/thefrosty/wp-utilities@3/assets/js/%s%s.js', self::HANDLE, $min),
             ['select2', self::HANDLE_UTILITY_FUNCTIONS],
-            in_footer: true
+            args: ['in_footer' => true]
         );
         wp_enqueue_style('select2');
         wp_enqueue_script(self::HANDLE);

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheFrosty\WpUtilities;
+
+use function boolval;
+use function is_array;
+
+/**
+ * 6.3.0 Stub fpr PHP 8.0+.
+ * Registers a new script.
+ * Registers a script to be enqueued later using the wp_enqueue_script() function.
+ * @param string $handle Name of the script. Should be unique.
+ * @param string|false $src Full URL of the script, or path of the script relative to the WordPress root directory.
+ *                                    If source is set to false, script is an alias of other scripts it depends on.
+ * @param string[] $deps Optional. An array of registered script handles this script depends on. Default empty array.
+ * @param string|bool|int|null $ver Optional. String specifying script version number, if it has one, which is added to
+ *     the URL as a query string for cache busting purposes. If version is set to false, a version number is
+ *     automatically added equal to current installed WordPress version. If set to null, no version is added.
+ * @param array|bool $args {
+ *      Optional. An array of additional script loading strategies. Default empty array.
+ *      Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer. Default
+ *     false.
+ * @type string $strategy Optional. If provided, may be either 'defer' or 'async'.
+ * @type bool $in_footer Optional. Whether to print the script in the footer. Default 'false'.
+ * }
+ * @return bool Whether the script has been registered. True on success, false on failure.
+ * @see WP_Dependencies::add()
+ * @see WP_Dependencies::add_data()
+ * @since 2.1.0
+ * @since 4.3.0 A return value was added.
+ * @since 6.3.0 The $in_footer parameter of type boolean was overloaded to be an $args parameter of type array.
+ */
+function wp_register_script(
+    string $handle,
+    string|false $src,
+    array $deps = [],
+    mixed $ver = false,
+    bool|array $args = []
+): bool {
+    if (!is_array($args)) {
+        $args = [
+            'in_footer' => boolval($args),
+        ];
+    }
+
+    if (\version_compare(\get_bloginfo('version'), '6.3') >= 0) {
+        return \wp_register_script($handle, $src, $deps, $ver, $args);
+    }
+
+    return \wp_register_script($handle, $src, $deps, $ver, $args['in_footer']);
+}
+
+/**
+ * 6.3.0 Stub fpr PHP 8.0+.
+ * Enqueues a script.
+ * Registers the script if $src provided (does NOT overwrite), and enqueues it.
+ * @param string $handle Name of the script. Should be unique.
+ * @param string|false $src Full URL of the script, or path of the script relative to the WordPress root directory.
+ *                                    Default empty.
+ * @param string[] $deps Optional. An array of registered script handles this script depends on. Default empty array.
+ * @param string|bool|int|null $ver Optional. String specifying script version number, if it has one, which is added to
+ *     the URL as a query string for cache busting purposes. If version is set to false, a version number is
+ *     automatically added equal to current installed WordPress version. If set to null, no version is added.
+ * @param array|bool $args {
+ *      Optional. An array of additional script loading strategies. Default empty array.
+ *      Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer. Default
+ *     false.
+ * @see WP_Dependencies::add()
+ * @see WP_Dependencies::add_data()
+ * @see WP_Dependencies::enqueue()
+ * @since 2.1.0
+ * @since 6.3.0 The $in_footer parameter of type boolean was overloaded to be an $args parameter of type array.
+ */
+function wp_enqueue_script(
+    string $handle,
+    string|false $src = '',
+    array $deps = [],
+    mixed $ver = false,
+    bool|array $args = []
+): void {
+    if (!is_array($args)) {
+        $args = [
+            'in_footer' => boolval($args),
+        ];
+    }
+
+    if (\version_compare(\get_bloginfo('version'), '6.3') >= 0) {
+        \wp_enqueue_script($handle, $src, $deps, $ver, $args);
+
+        return;
+    }
+
+    \wp_enqueue_script($handle, $src, $deps, $ver, $args['in_footer']);
+}


### PR DESCRIPTION
See https://make.wordpress.org/core/2023/07/14/registering-scripts-with-async-and-defer-attributes-in-wordpress-6-3/

> PHP Fatal error:  Uncaught Error: Unknown named parameter $in_footer