### PR TITLE
Avoid issue: SingletonInterface when expecting WpHooksInterface

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,6 @@
          beStrictAboutOutputDuringTests="true"
          displayDetailsOnPhpunitDeprecations="true"
          failOnPhpunitDeprecation="true"
-         failOnRisky="true"
          failOnWarning="true">
 
     <coverage>

--- a/src/Plugin/AbstractPlugin.php
+++ b/src/Plugin/AbstractPlugin.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace TheFrosty\WpUtilities\Plugin;
 
 use InvalidArgumentException;
-use TheFrosty\WpUtilities\Utils\SingletonInterface;
 use function add_action;
 use function call_user_func;
 use function class_implements;
@@ -422,11 +421,6 @@ abstract class AbstractPlugin implements PluginInterface
             throw new InvalidArgumentException(
                 sprintf('Expected a %s interface, but got %s', WpHooksInterface::class, $wp_hook)
             );
-        }
-
-        if (in_array(SingletonInterface::class, class_implements($wp_hook), true)) {
-            /** @var SingletonInterface $wp_hook */
-            return $wp_hook::getInstance();
         }
 
         return empty($args) ? new $wp_hook() : new $wp_hook(...$args);

--- a/src/Plugin/Init.php
+++ b/src/Plugin/Init.php
@@ -5,22 +5,16 @@ declare(strict_types=1);
 namespace TheFrosty\WpUtilities\Plugin;
 
 use ArrayIterator;
+use IteratorAggregate;
+use function array_key_exists;
 use function get_class;
 
 /**
  * Class Init
  * @package TheFrosty\WpUtilities\Plugin
  */
-final class Init implements \IteratorAggregate
+final class Init implements IteratorAggregate
 {
-
-    /**
-     * Helper property to check whether the object has been initiated
-     * or loaded. So this class can call `initialize()` method more than once.
-     * @deprecated
-     */
-    private const PROPERTY = 'initiated';
-
     /**
      * A container for objects that have been initiated.
      * @var array $initiated
@@ -63,7 +57,7 @@ final class Init implements \IteratorAggregate
     public function initialize(): void
     {
         foreach ($this as $wp_hook) {
-            if ($wp_hook instanceof WpHooksInterface && !\array_key_exists(get_class($wp_hook), $this->initiated)) {
+            if ($wp_hook instanceof WpHooksInterface && !array_key_exists(get_class($wp_hook), $this->initiated)) {
                 $this->initiated[get_class($wp_hook)] = true;
                 $wp_hook->addHooks();
             }

--- a/src/Plugin/Init.php
+++ b/src/Plugin/Init.php
@@ -7,7 +7,6 @@ namespace TheFrosty\WpUtilities\Plugin;
 use ArrayIterator;
 use IteratorAggregate;
 use function array_key_exists;
-use function get_class;
 
 /**
  * Class Init
@@ -57,8 +56,8 @@ final class Init implements IteratorAggregate
     public function initialize(): void
     {
         foreach ($this as $wp_hook) {
-            if ($wp_hook instanceof WpHooksInterface && !array_key_exists(get_class($wp_hook), $this->initiated)) {
-                $this->initiated[get_class($wp_hook)] = true;
+            if ($wp_hook instanceof WpHooksInterface && !array_key_exists($wp_hook::class, $this->initiated)) {
+                $this->initiated[$wp_hook::class] = true;
                 $wp_hook->addHooks();
             }
         }
@@ -91,7 +90,7 @@ final class Init implements IteratorAggregate
     {
         $wp_hooks = $this->getWpHooks();
         foreach ($wp_hooks as $key => $object) {
-            if (get_class($object) === $class_name) {
+            if ($object::class === $class_name) {
                 return $object[$key];
             }
         }

--- a/tests/unit/Plugin/AbstractPluginTest.php
+++ b/tests/unit/Plugin/AbstractPluginTest.php
@@ -1,20 +1,28 @@
 <?php
+
 declare(strict_types=1);
 
 namespace TheFrosty\WpUtilities\Tests\Plugin;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use ReflectionObject;
 use TheFrosty\WpUtilities\Plugin\AbstractPlugin;
+use TheFrosty\WpUtilities\Plugin\Init;
 use TheFrosty\WpUtilities\Plugin\Plugin;
 use TheFrosty\WpUtilities\Plugin\PluginInterface;
+use TheFrosty\WpUtilities\Plugin\WpHooksInterface;
 use TheFrosty\WpUtilities\Tests\Plugin\Framework\TestCase;
+use function do_action;
+use function get_class;
 
 /**
  * Class AbstractPluginTest
  * @package TheFrosty\WpUtilities\Test\Plugin
  */
 #[CoversClass(AbstractPlugin::class)]
+#[UsesClass(Init::class)]
 class AbstractPluginTest extends TestCase
 {
 
@@ -40,10 +48,9 @@ class AbstractPluginTest extends TestCase
     public function testGetBasename(): void
     {
         $basename = 'plugin/plugin.php';
-        $plugin = $this->plugin;
-        $plugin->setBasename($basename);
-        $this->assertInstanceOf(\get_class($plugin), $plugin);
-        $this->assertSame($basename, $plugin->getBasename());
+        $this->plugin->setBasename($basename);
+        $this->assertInstanceOf(get_class($this->plugin), $this->plugin);
+        $this->assertSame($basename, $this->plugin->getBasename());
     }
 
     /**
@@ -51,14 +58,13 @@ class AbstractPluginTest extends TestCase
      */
     public function testGetDirectory(): void
     {
-        $plugin = $this->plugin;
-        $plugin->setDirectory('/wp-content/plugins');
-        $this->assertInstanceOf(get_class($plugin), $plugin);
-        $this->assertSame('/wp-content/plugins/', $plugin->getDirectory());
+        $this->plugin->setDirectory('/wp-content/plugins');
+        $this->assertInstanceOf(get_class($this->plugin), $this->plugin);
+        $this->assertSame('/wp-content/plugins/', $this->plugin->getDirectory());
 
         // Test with trailing slash.
-        $plugin->setDirectory('/wp-content/plugins/');
-        $this->assertSame('/wp-content/plugins/', $plugin->getDirectory());
+        $this->plugin->setDirectory('/wp-content/plugins/');
+        $this->assertSame('/wp-content/plugins/', $this->plugin->getDirectory());
     }
 
     /**
@@ -67,10 +73,17 @@ class AbstractPluginTest extends TestCase
     public function testGetFile(): void
     {
         $file = '/wp-content/plugins/plugin/plugin.php';
-        $plugin = $this->plugin;
-        $plugin->setFile($file);
-        $this->assertInstanceOf(get_class($plugin), $plugin);
-        $this->assertSame($file, $plugin->getFile());
+        $this->plugin->setFile($file);
+        $this->assertInstanceOf(get_class($this->plugin), $this->plugin);
+        $this->assertSame($file, $this->plugin->getFile());
+    }
+
+    /**
+     * Test getFile().
+     */
+    public function testGetFileTime(): void
+    {
+        $this->assertNull($this->plugin->getFileTime());
     }
 
     /**
@@ -78,11 +91,10 @@ class AbstractPluginTest extends TestCase
      */
     public function testGetPath(): void
     {
-        $plugin = $this->plugin;
-        $plugin->setDirectory('/wp-content/plugins');
-        $this->assertInstanceOf(get_class($plugin), $plugin);
-        $this->assertSame('/wp-content/plugins/name', $plugin->getPath('name'));
-        $this->assertSame('/wp-content/plugins/name', $plugin->getPath('/name'));
+        $this->plugin->setDirectory('/wp-content/plugins');
+        $this->assertInstanceOf(get_class($this->plugin), $this->plugin);
+        $this->assertSame('/wp-content/plugins/name', $this->plugin->getPath('name'));
+        $this->assertSame('/wp-content/plugins/name', $this->plugin->getPath('/name'));
     }
 
     /**
@@ -91,10 +103,9 @@ class AbstractPluginTest extends TestCase
     public function testGetSlug(): void
     {
         $slug = 'crate';
-        $plugin = $this->plugin;
-        $plugin->setSlug($slug);
-        $this->assertInstanceOf(get_class($plugin), $plugin);
-        $this->assertSame($slug, $plugin->getSlug());
+        $this->plugin->setSlug($slug);
+        $this->assertInstanceOf(get_class($this->plugin), $this->plugin);
+        $this->assertSame($slug, $this->plugin->getSlug());
     }
 
     /**
@@ -103,14 +114,170 @@ class AbstractPluginTest extends TestCase
     public function testGetUrl(): void
     {
         $url = 'https://example.com/wp-content/plugins/plugin';
-        $plugin = $this->plugin;
-        $plugin->setUrl($url);
-        $this->assertInstanceOf(get_class($plugin), $plugin);
-        $this->assertSame($url . '/', $plugin->getUrl());
+        $this->plugin->setUrl($url);
+        $this->assertInstanceOf(get_class($this->plugin), $this->plugin);
+        $this->assertSame($url . '/', $this->plugin->getUrl());
 
         // Test with trailing slash.
         $url = 'https://example.com/wp-content/plugins/plugin/';
-        $plugin->setUrl($url);
-        $this->assertSame($url, $plugin->getUrl());
+        $this->plugin->setUrl($url);
+        $this->assertSame($url, $this->plugin->getUrl());
+    }
+
+    public function testAdd(): void
+    {
+        $class = new class implements WpHooksInterface {
+            public function addHooks(): void
+            {
+            }
+        };
+
+        $this->plugin->setInit(new Init());
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $instance = $this->plugin->add($class);
+        $this->assertInstanceOf(PluginInterface::class, $instance);
+        $this->assertNotEmpty($this->plugin->getInit()->getWpHooks());
+    }
+
+    public function testAddIfCondition(): void
+    {
+        $class = new class implements WpHooksInterface {
+            public function addHooks(): void
+            {
+            }
+        };
+
+        $this->plugin->setInit(new Init());
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addIfCondition($class::class, false);
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addIfCondition($class::class, true);
+        $this->assertNotEmpty($this->plugin->getInit()->getWpHooks());
+    }
+
+    public function testAddIfConditionDeferred(): void
+    {
+        $class = new class implements WpHooksInterface {
+            public function addHooks(): void
+            {
+            }
+        };
+
+        $this->plugin->setInit(new Init());
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addIfConditionDeferred($class::class, false, 'init');
+        do_action('init');
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addIfConditionDeferred($class::class, true, 'init');
+        do_action('init');
+        $this->assertNotEmpty($this->plugin->getInit()->getWpHooks());
+    }
+
+    public function testAddOnCondition(): void
+    {
+        $class = new class implements WpHooksInterface {
+            public function addHooks(): void
+            {
+            }
+        };
+
+        $this->plugin->setInit(new Init());
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addOnCondition($class::class, static fn(): bool => false);
+        do_action('init');
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addOnCondition($class::class, static fn(): bool => true);
+        do_action('init');
+        $this->assertNotEmpty($this->plugin->getInit()->getWpHooks());
+    }
+
+    public function testAddOnConditionDeferred(): void
+    {
+        $class = new class implements WpHooksInterface {
+            public function addHooks(): void
+            {
+            }
+        };
+
+        $this->plugin->setInit(new Init());
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addOnConditionDeferred($class::class, '__return_false');
+        do_action('plugins_loaded');
+        do_action('init');
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addOnConditionDeferred($class::class, '__return_true');
+        do_action('plugins_loaded');
+        do_action('init');
+        $this->assertNotEmpty($this->plugin->getInit()->getWpHooks());
+    }
+
+    public function testAddOnHook(): void
+    {
+        $class = new class implements WpHooksInterface {
+            public function addHooks(): void
+            {
+            }
+        };
+
+        $this->plugin->setInit(new Init());
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addOnHook($class::class);
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addOnHook($class::class);
+        do_action('init');
+        $this->assertNotEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addOnHook($class::class, admin_only: true);
+        do_action('admin_init');
+        $this->assertCount(2, $this->plugin->getInit()->getWpHooks());
+    }
+
+    public function testAddOnHookDeferred(): void
+    {
+        $class = new class implements WpHooksInterface {
+            public function addHooks(): void
+            {
+            }
+        };
+
+        $this->plugin->setInit(new Init());
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addOnHookDeferred($class::class);
+        do_action('init');
+        $this->assertEmpty($this->plugin->getInit()->getWpHooks());
+        $this->plugin->addOnHookDeferred($class::class);
+        do_action('init');
+        $this->assertNotEmpty($this->plugin->getInit()->getWpHooks());
+    }
+
+    public function testInitialize(): void
+    {
+        $class = new class implements WpHooksInterface {
+            public function addHooks(): void
+            {
+            }
+        };
+        $this->plugin->setInit(new Init());
+        $this->plugin->add($class);
+        $reflection = new ReflectionObject($this->plugin->getInit());
+        $this->assertEmpty($reflection->getProperty('initiated')->getValue($this->plugin->getInit()));
+        $this->plugin->initialize();
+        $this->assertNotEmpty($reflection->getProperty('initiated')->getValue($this->plugin->getInit()));
+    }
+
+    public function testGetWpHook(): void
+    {
+        $class = new class implements WpHooksInterface {
+            public function addHooks(): void
+            {
+            }
+        };
+        $this->plugin->setInit(new Init());
+        $getWpHook = $this->reflection->getMethod('getWpHook');
+        $this->assertInstanceOf(WpHooksInterface::class, $getWpHook->invoke($this->plugin, $class::class));
+
+        $class = new class {
+        };
+        $this->expectException(InvalidArgumentException::class);
+        $getWpHook->invoke($this->plugin, $class::class);
     }
 }


### PR DESCRIPTION
Singleton should really never be passed to the Initiator. Since its got its own provider when registered via Init()->getWpHookObject(CLASS)