### PR TITLE
Load the text domain on init rather than plugins_loaded. 

### DIFF
--- a/src/Plugin/Provider/I18n.php
+++ b/src/Plugin/Provider/I18n.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace TheFrosty\WpUtilities\Plugin\Provider;
 
@@ -6,6 +8,9 @@ use TheFrosty\WpUtilities\Plugin\HooksTrait;
 use TheFrosty\WpUtilities\Plugin\PluginAwareInterface;
 use TheFrosty\WpUtilities\Plugin\PluginAwareTrait;
 use TheFrosty\WpUtilities\Plugin\WpHooksInterface;
+use function did_action;
+use function dirname;
+use function load_plugin_textdomain;
 
 /**
  * Internationalization class.
@@ -17,17 +22,16 @@ class I18n implements PluginAwareInterface, WpHooksInterface
 
     /**
      * Register hooks.
-     *
-     * Loads the text domain during the `plugins_loaded` action.
+     * Loads the text domain during the `init` action.
      */
     public function addHooks(): void
     {
-        if (\did_action('plugins_loaded')) {
+        if (did_action('init')) {
             $this->loadTextDomain();
 
             return;
         }
-        $this->addAction('plugins_loaded', [$this, 'loadTextDomain']);
+        $this->addAction('init', [$this, 'loadTextDomain']);
     }
 
     /**
@@ -35,10 +39,10 @@ class I18n implements PluginAwareInterface, WpHooksInterface
      */
     protected function loadTextDomain(): void
     {
-        \load_plugin_textdomain(
+        load_plugin_textdomain(
             $this->getPlugin()->getSlug(),
             false,
-            \dirname($this->getPlugin()->getBasename()) . '/languages'
+            dirname($this->getPlugin()->getBasename()) . '/languages'
         );
     }
 }

--- a/tests/unit/Plugin/Provider/I18nTest.php
+++ b/tests/unit/Plugin/Provider/I18nTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheFrosty\WpUtilities\Tests\Plugin\Provider;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use ReflectionObject;
+use TheFrosty\WpUtilities\Plugin\AbstractPlugin;
+use TheFrosty\WpUtilities\Plugin\ContainerAwareTrait;
+use TheFrosty\WpUtilities\Plugin\PluginFactory;
+use TheFrosty\WpUtilities\Plugin\Provider\I18n;
+use TheFrosty\WpUtilities\Plugin\TemplateLoader;
+use TheFrosty\WpUtilities\Tests\Plugin\Framework\TestCase;
+use WP_Textdomain_Registry;
+use function do_action;
+
+/**
+ * Class I18nTest
+ * @package TheFrosty\WpUtilities\Tests\Plugin\Provider
+ */
+#[CoversClass(I18n::class)]
+#[UsesClass(AbstractPlugin::class)]
+#[UsesClass(ContainerAwareTrait::class)]
+#[UsesClass(PluginFactory::class)]
+#[UsesClass(TemplateLoader::class)]
+class I18nTest extends TestCase
+{
+
+    protected I18n $i18n;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->plugin = PluginFactory::create('i18n');
+        $this->i18n = new I18n();
+        $this->i18n->setPlugin($this->plugin);
+        $this->reflection = new ReflectionObject($this->i18n);
+    }
+
+    public function tearDown(): void
+    {
+        unset($this->plugin);
+        parent::tearDown();
+    }
+
+    public function testAddHooks(): void
+    {
+        $this->i18n->addHooks();
+        $this->assertTrue($this->getRegistry()->has($this->i18n->getPlugin()->getSlug()));
+    }
+
+    public function testLoadTextDomain(): void
+    {
+        $loadTextDomain = $this->reflection->getMethod('loadTextDomain');
+        $loadTextDomain->invoke($this->i18n);
+        $this->assertTrue($this->getRegistry()->has($this->i18n->getPlugin()->getSlug()));
+    }
+
+    private function getRegistry(): WP_Textdomain_Registry
+    {
+        global $wp_textdomain_registry;
+        return $wp_textdomain_registry;
+    }
+}


### PR DESCRIPTION
See https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/