### PR TITLE
Rename InstanceOf.php to IsInstanceOf.php

### DIFF
--- a/src/Api/ValidationRules/IsInstanceOf.php
+++ b/src/Api/ValidationRules/IsInstanceOf.php
@@ -10,10 +10,10 @@ use function is_subclass_of;
 use function sprintf;
 
 /**
- * Class InstanceOfRule
+ * Class IsInstanceOf
  * @package TheFrosty\WpUtilities\Api\Rules
  */
-class InstanceOfRule implements Rule
+class IsInstanceOf implements Rule
 {
 
     protected string $field;


### PR DESCRIPTION
Fixes `Class TheFrosty\WpUtilities\Api\ValidationRules\InstanceOfRule located in ./src/Api/ValidationRules/InstanceOf.php` does not comply with psr-4 autoloading standard (rule: TheFrosty\WpUtilities\ => ./src). Skipping.
